### PR TITLE
Using alpine base image with Azure CLI and fixing runtime error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
-FROM ubuntu:21.04
+FROM mcr.microsoft.com/azure-cli:2.9.1
 
-ARG DEBIAN_FRONTEND=noninteractive
-RUN apt update && apt install nodejs npm curl -y
-RUN curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+RUN apk add --update nodejs nodejs-npm
 RUN az aks install-cli
 
 WORKDIR /app
@@ -13,6 +11,6 @@ RUN npm install
 COPY . .
 RUN npm install -g
 
-
-RUN useradd -ms /bin/bash boxboat
+# Create a group and user
+RUN addgroup -S boxboat && adduser -S boxboat -G boxboat
 USER boxboat

--- a/helpers/commandHelpers.js
+++ b/helpers/commandHelpers.js
@@ -82,7 +82,7 @@ export async function doesResourceExist(resourceName) {
   try {
     var result = await executeCommand(`kubectl api-resources | awk -F ' ' '{ print $1 }' | grep '${resourceName}'`);
 
-    return result?.stdout? true: false;
+    return result.stdout? true: false;
   }
   catch {
     return false;


### PR DESCRIPTION
- Using `mcr.microsoft.com/azure-cli:2.9.1` for the base image.
- Fixing runtime error with null coalescer