### PR TITLE
Shortened the alias for the health-check when running as a CLI tool

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ RUN npm install
 
 COPY . .
 RUN npm install -g
+RUN npm link
 
 # Create a group and user
 RUN addgroup -S boxboat && adduser -S boxboat -G boxboat

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "bin": {
-    "boxboat-aks-healthcheck": "./index.js"
+    "aks-hc": "./index.js"
   },
   "author": "BoxBoat",
   "license": "ISC",


### PR DESCRIPTION
Changed it to `aks-hc`

Also, registering it within the container as well.