### PR TITLE
Starting to break down the commands into small nested commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ az aks get-credentials -g <resource group> -n <cluster name> --admin
 
 $ az account set -s <subscription id>
 
-$ aks-hc -g <resource group> -n <cluster name>
+$ aks-hc check all -g <resource group> -n <cluster name>
 
 $ exit
 ```

--- a/index.js
+++ b/index.js
@@ -123,34 +123,32 @@ async function main(options) {
   DisasterRecovery.checkForVelero(pods);
 }
 
-//
-// Entrypoint
-//
-(async () => {
-  try {
+// Build up the program
+const program = new Command();
+program
+  .name('boxboat-aks-healthcheck')
+  .description('Health checks an AKS cluster using BoxBoat best practices');
+  
+const check = program.command('check');
+check
+  .command('azure')
+  .action(() => {
+    console.log('TODO checking azure');
+  });
 
-    // Build up the program
-    const program = new Command();
-    program
-      .name('boxboat-aks-healthcheck')
-      .description('Healthchecks an AKS cluster using BoxBoat best practices')
-      .requiredOption('-g, --resource-group <group>', 'Resource group of AKS cluster')
-      .requiredOption('-n, --name <name>', 'Name of AKS cluster')
-      .option('-r, --image-registries <registries>', 'A comma-separated list of Azure Container Registry names used with the cluster')
-      .option('-i, --ignore-namespaces <namespaces>', 'A comma-separated list of namespaces to ignore when doing analysis');
+check
+  .command('kubernetes')
+  .action(() => {
+    console.log('TODO checking kubernetes');
+  });
 
-    // Parse command
-    program.parse();
+check
+  .command('all')
+  .requiredOption('-g, --resource-group <group>', 'Resource group of AKS cluster')
+  .requiredOption('-n, --name <name>', 'Name of AKS cluster')
+  .option('-r, --image-registries <registries>', 'A comma-separated list of Azure Container Registry names used with the cluster')
+  .option('-i, --ignore-namespaces <namespaces>', 'A comma-separated list of namespaces to ignore when doing analysis')
+  .action(main);
 
-    // Execute main
-    const opts = program.opts();
-    await main(opts);
-
-    // If we make it here, main has completed
-    // exit the process to stop any promises that are waiting to timeout
-    process.exit(0);
-  } catch (e) {
-    console.log(chalk.red(`An unexpected error occurred: ${e}`));
-    process.exit(1);
-  }
-})();
+// Parse command
+program.parse(process.argv);

--- a/start-from-aci.sh
+++ b/start-from-aci.sh
@@ -24,4 +24,4 @@ az login --identity --verbose
 az aks get-credentials -g $RESOURCE_GROUP -n $CLUSTER_NAME 
 
 echo "Logged in. Starting health check."
-aks-hc -n $CLUSTER_NAME -g $RESOURCE_GROUP | tee $OUTPUT_FILE_NAME
+aks-hc check all -n $CLUSTER_NAME -g $RESOURCE_GROUP | tee $OUTPUT_FILE_NAME


### PR DESCRIPTION
Unfortunately, there's no "default" commands concept in Commander.js. 

So, this are breaking changes. 

Moved the current functionality to 

`aks-hc check all`

Then, started two new nested commands that don't do anything. 

`aks-hc check azure`

And, 

`aks-hc check kubernetes`

Here's what the experience is like

``` shell
bash-5.0$ aks-hc
Usage: boxboat-aks-healthcheck [options] [command]

Health checks an AKS cluster using BoxBoat best practices

Options:
  -h, --help      display help for command

Commands:
  check
  help [command]  display help for command
bash-5.0$ aks-hc check
Usage: boxboat-aks-healthcheck check [options] [command]

Options:
  -h, --help      display help for command

Commands:
  azure
  kubernetes
  all [options]
  help [command]  display help for command
bash-5.0$ aks-hc check azure
checking azure
```