### PR TITLE
Refactoring to split Azure and Kubernetes checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,7 +58,6 @@ async function checkAzure(options) {
   console.log();
   console.log(chalk.bgWhite(chalk.black('               Scanning Image Management Items               ')));
   ImageManagement.checkForPrivateEndpointsOnRegistries(containerRegistries);
-  //TODO why is this async?
   await ImageManagement.checkForAksAcrRbacIntegration(clusterDetails, containerRegistries);
 }
 


### PR DESCRIPTION
Grouped checks into Azure and Kubernetes checks. Didn't seem to have any checks that are in-between.

`aks-hc check all` runs all checks like before.

`aks-hc check azure` runs all Azure checks.

`aks-hc check kubernetes` runs all Kubernetes checks.