### PR TITLE
Showing single table results for Azure and Kubernetes checks 📈 

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,6 +12,9 @@ import * as ClusterSetup from './modules/clusterSetup.js';
 import * as DisasterRecovery from './modules/disasterRecovery.js';
 import { equalsIgnoreCase } from './helpers/stringCompare.js';
 
+//
+// Sort the results from checks by the Check ID. Then show a table.
+//
 function showTableFromResults(results) {
   let sortedResults = results.sort((a,b) => a.checkId > b.checkId? 1: -1);
   const transformed = sortedResults.reduce((re, { checkId, ...x }) => { re[checkId] = x; return re }, {})


### PR DESCRIPTION
Also, the table is sorted by Check ID

Example output

```
┌─────────┬───────────┬─────────────────┐
│ (index) │  status   │    severity     │
├─────────┼───────────┼─────────────────┤
│  CSP-2  │   false   │     'High'      │
│  CSP-3  │   true    │     'High'      │
│  CSP-4  │   false   │    'Medium'     │
│  CSP-7  │   true    │     'High'      │
│  CSP-8  │ undefined │ 'Informational' │
│  CSP-9  │   true    │    'Medium'     │
│  DEV-1  │   false   │    'Medium'     │
│ DEV-10  │   false   │     'High'      │
│ DEV-11  │   false   │     'High'      │
│  DEV-2  │   false   │    'Medium'     │
│  DEV-3  │   false   │    'Medium'     │
│  DEV-4  │   false   │     'High'      │
│  DEV-5  │   false   │     'High'      │
│  DEV-6  │   false   │      'Low'      │
│  DEV-7  │   false   │    'Medium'     │
│  DEV-9  │   true    │     'High'      │
│  DR-2   │   false   │     'High'      │
│  DR-5   │   false   │    'Medium'     │
│  DR-6   │   false   │     'High'      │
│  IMG-3  │   false   │     'High'      │
│  IMG-4  │   false   │    'Medium'     │
│  IMG-5  │   true    │     'High'      │
│  IMG-6  │   true    │    'Medium'     │
│  IMG-8  │   false   │     'High'      │
└─────────┴───────────┴─────────────────┘
```