### PR TITLE
Cleaning up more of the output

### DIFF
--- a/checks-definition.json
+++ b/checks-definition.json
@@ -8,6 +8,10 @@
         "description": "Implement a proper readiness/startup probe"
     },
     {
+        "checkId": "DEV-2B",
+        "description": "Implement a proper startup probes"
+    },
+    {
         "checkId": "DEV-3",
         "description": "Implement a proper prestop hook"
     },

--- a/modules/development.js
+++ b/modules/development.js
@@ -1,6 +1,9 @@
 import chalk from "chalk"
 import { ResultStatus } from '../helpers/commandStatus.js';
 import { Severity } from '../helpers/commandSeverity.js';
+import { EOL } from 'os';
+
+const space = '            '
 
 //
 // Checks for any pods without liveness probes
@@ -9,6 +12,8 @@ export function checkForLivenessProbes(pods) {
 
   console.log(chalk.white("Checking for liveness probes..."));
 
+  let details = []
+
   // Find all the pods without liveness probes
   var podsWithoutLivenessProbes = pods
     .items
@@ -16,18 +21,30 @@ export function checkForLivenessProbes(pods) {
 
   // Log output
   if (podsWithoutLivenessProbes.length) {
-    console.log(chalk.red(`--- Found ${podsWithoutLivenessProbes.length} pods without liveness probes`));
+
+    let message = `Found ${podsWithoutLivenessProbes.length} pods without liveness probes`;
+
     if (global.verbose) {
-      podsWithoutLivenessProbes.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
+      podsWithoutLivenessProbes.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
     }
+
+    details.push({
+      status:  ResultStatus.Fail,
+      message: message}
+      );
+    
   } else {
-    console.log(chalk.green('--- All pods have liveness probes'));
+    details.push({
+      status:  ResultStatus.Pass,
+      message: 'All pods have liveness probes'}
+      );
   }
 
   return {
     checkId: 'DEV-1',
     status: !podsWithoutLivenessProbes.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Medium
+    severity: Severity.Medium,
+    details: details
   }
 }
 
@@ -38,6 +55,8 @@ export function checkForReadinessProbes(pods) {
 
   console.log(chalk.white("Checking for readiness probes..."));
 
+  let details = []
+
   // Find all the pods without readiness probes
   var podsWithoutReadinessProbes = pods
     .items
@@ -45,18 +64,29 @@ export function checkForReadinessProbes(pods) {
 
   // Log output
   if (podsWithoutReadinessProbes.length) {
-    console.log(chalk.red(`--- Found ${podsWithoutReadinessProbes.length} pods without readiness probes`));
+
+    let message = `Found ${podsWithoutReadinessProbes.length} pods without readiness probes`;
+
     if (global.verbose) {
-      podsWithoutReadinessProbes.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
+      podsWithoutReadinessProbes.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
     }
+
+    details.push({
+      status:  ResultStatus.Fail,
+      message: message}
+      );
   } else {
-    console.log(chalk.green('--- All pods have readiness probes'));
+    details.push({
+      status:  ResultStatus.Pass,
+      message: 'All pods have readiness probes'}
+      );
   }
 
   return {
     checkId: 'DEV-2',
     status: !podsWithoutReadinessProbes.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Medium
+    severity: Severity.Medium,
+    details: details
   }
 }
 
@@ -66,6 +96,8 @@ export function checkForReadinessProbes(pods) {
 export function checkForStartupProbes(pods) {
 
   console.log(chalk.white("Checking for startup probes..."));
+
+  let details = []
 
   // Find all the pods without startup probes
   var podsWithoutStartupProbes = pods
@@ -85,7 +117,8 @@ export function checkForStartupProbes(pods) {
   return {
     checkId: 'DEV-2',
     status: !podsWithoutStartupProbes.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Medium
+    severity: Severity.Medium,
+    details: details
   }
 }
 
@@ -95,6 +128,8 @@ export function checkForStartupProbes(pods) {
 export function checkForPreStopHooks(pods) {
 
   console.log(chalk.white("Checking for preStop hooks..."));
+
+  let details = []
 
   // Find all the pods without preStop hooks
   var podsWithoutPreStopHooks = pods
@@ -114,7 +149,8 @@ export function checkForPreStopHooks(pods) {
   return {
     checkId: 'DEV-3',
     status: !podsWithoutPreStopHooks.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Medium
+    severity: Severity.Medium,
+    details: details
   }
 }
 
@@ -124,6 +160,8 @@ export function checkForPreStopHooks(pods) {
 export function checkForSingleReplicas(deployments) {
 
   console.log(chalk.white("Checking for single replica deployments..."));
+
+  let details = []
 
   // Find all the deployments with a single replica
   var deploymentsWithOneReplica = deployments
@@ -143,7 +181,8 @@ export function checkForSingleReplicas(deployments) {
   return {
     checkId: 'DEV-4',
     status: !deploymentsWithOneReplica.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.High
+    severity: Severity.High,
+    details: details
   }
 }
 
@@ -153,6 +192,8 @@ export function checkForSingleReplicas(deployments) {
 export function checkForTags(resources) {
 
   console.log(chalk.white("Checking for resources without labels or annotations..."));
+
+  let details = []
 
   // Filter out the default namespace resource - this is usually never tagged
   var allResources = resources
@@ -178,7 +219,8 @@ export function checkForTags(resources) {
   return {
     checkId: 'DEV-5',
     status: !resourcesWithoutTags.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.High
+    severity: Severity.High,
+    details: details
   }
 }
 
@@ -188,6 +230,8 @@ export function checkForTags(resources) {
 export function checkForHorizontalPodAutoscalers(namespaces, autoScalers) {
 
   console.log(chalk.white("Checking for namespaces without Horizontal Pod Autoscalers..."));
+
+  let details = []
 
   // Get all namespaces without any autoscalers
   var namespacesWithoutAutoscalers = namespaces
@@ -206,7 +250,8 @@ export function checkForHorizontalPodAutoscalers(namespaces, autoScalers) {
   return {
     checkId: 'DEV-6',
     status: !namespacesWithoutAutoscalers.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Low
+    severity: Severity.Low,
+    details: details
   }
 }
 
@@ -216,6 +261,8 @@ export function checkForHorizontalPodAutoscalers(namespaces, autoScalers) {
 export function checkForAzureSecretsStoreProvider(pods) {
 
   console.log(chalk.white("Checking for Azure secrets store provider..."));
+
+  let details = []
 
   // Grab all the containers for all the pods
   var containerImages = pods
@@ -237,7 +284,8 @@ export function checkForAzureSecretsStoreProvider(pods) {
   return {
     checkId: 'DEV-7',
     status: secretsStoreProviderExists.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Medium
+    severity: Severity.Medium,
+    details: details
   }
 }
 
@@ -247,6 +295,8 @@ export function checkForAzureSecretsStoreProvider(pods) {
 export function checkForAzureManagedPodIdentity(clusterDetails) {
 
   console.log(chalk.white("Checking for Azure Managed Identity for pods..."));
+
+  let details = []
 
   // Determine if managed identity for pods is enabled
   var podIdentityProfile = clusterDetails.podIdentityProfile;
@@ -262,7 +312,8 @@ export function checkForAzureManagedPodIdentity(clusterDetails) {
   return {
     checkId: 'DEV-8',
     status: managedPodIdentityEnabled? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.Medium
+    severity: Severity.Medium,
+    details: details
   }
 }
 
@@ -272,6 +323,8 @@ export function checkForAzureManagedPodIdentity(clusterDetails) {
 export function checkForPodsInDefaultNamespace(pods) {
 
   console.log(chalk.white("Checking for pods in default namespace..."));
+
+  let details = []
 
   // Grab the pods running in the default namespace
   var podsInDefaultNamespace = pods
@@ -288,7 +341,8 @@ export function checkForPodsInDefaultNamespace(pods) {
   return {
     checkId: 'DEV-9',
     status: !podsInDefaultNamespace.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.High
+    severity: Severity.High,
+    details: details
   }
 }
 
@@ -298,6 +352,8 @@ export function checkForPodsInDefaultNamespace(pods) {
 export function checkForPodsWithoutRequestsOrLimits(pods) {
 
   console.log(chalk.white("Checking for pods without resource requests/limits..."));
+
+  let details = []
 
   // Grab the pods with no requests or limits defined
   var podsWithNoRequestsOrLimits = pods
@@ -317,7 +373,8 @@ export function checkForPodsWithoutRequestsOrLimits(pods) {
   return {
     checkId: 'DEV-10',
     status: !podsWithNoRequestsOrLimits.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.High
+    severity: Severity.High,
+    details: details
   }
 }
 
@@ -327,6 +384,8 @@ export function checkForPodsWithoutRequestsOrLimits(pods) {
 export function checkForPodsWithDefaultSecurityContext(pods) {
 
   console.log(chalk.white("Checking for pods with default security context..."));
+
+  let details = []
 
   // Grab the pods with no requests or limits defined
   var podsWithDefaultSecurityContext = pods
@@ -348,6 +407,7 @@ export function checkForPodsWithDefaultSecurityContext(pods) {
   return {
     checkId: 'DEV-11',
     status: !podsWithDefaultSecurityContext.length? ResultStatus.Pass: ResultStatus.Fail,
-    severity: Severity.High
+    severity: Severity.High,
+    details: details
   }
 }

--- a/modules/development.js
+++ b/modules/development.js
@@ -290,9 +290,23 @@ export function checkForHorizontalPodAutoscalers(namespaces, autoScalers) {
 
   // Log output
   if (namespacesWithoutAutoscalers.length) {
-    console.log(chalk.red(`--- Found ${namespacesWithoutAutoscalers.length} namespaces without any Horizontal Pod Autoscalers`));
+    let message = `Found ${namespacesWithoutAutoscalers.length} namespaces without any Horizontal Pod Autoscalers`;
+
+    if (global.verbose) {
+      namespacesWithoutAutoscalers.forEach(x => message += `${EOL}${space}${x}`);
+    }
+
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- All namespaces contain Horizontal Pod Autoscalers'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'All namespaces contain Horizontal Pod Autoscalers'
+    }
+    );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -245,12 +245,23 @@ export function checkForTags(resources) {
 
   // Log output
   if (resourcesWithoutTags.length) {
-    console.log(chalk.red(`--- Found ${resourcesWithoutTags.length} resources without labels or annotations`));
+    let message = `Found ${resourcesWithoutTags.length} resources without labels or annotations`;
+
     if (global.verbose) {
-      resourcesWithoutTags.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name} - ${x.kind}`)));
+      resourcesWithoutTags.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}/${x.kind}`);
     }
+
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- All resources have labels or annotations'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'All resources have labels or annotations'
+    }
+    );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -413,9 +413,24 @@ export function checkForPodsInDefaultNamespace(pods) {
 
   // Log output
   if (podsInDefaultNamespace.length) {
-    console.log(chalk.red(`--- Found ${podsInDefaultNamespace.length} pods running in the default namespace`));
+    let message = `Found ${podsInDefaultNamespace.length} pods running in the default namespace`;
+
+    if (global.verbose) {
+      podsInDefaultNamespace.forEach(x => message += `${EOL}${space}${x.metadata.name}`);
+    }
+
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- No pods running in default namespace'));
+
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'No pods running in default namespace'
+    }
+    );
   }
 
   return {
@@ -446,8 +461,24 @@ export function checkForPodsWithoutRequestsOrLimits(pods) {
     if (global.verbose) {
       podsWithNoRequestsOrLimits.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
     }
+
+    let message = `Found ${podsWithNoRequestsOrLimits.length} pods without either resource requests or limits`;
+
+    if (global.verbose) {
+      podsWithNoRequestsOrLimits.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
+    }
+
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- All pods have resource requests and limits'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'All pods have resource requests and limits'
+    }
+    );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -338,9 +338,18 @@ export function checkForAzureSecretsStoreProvider(pods) {
 
   // Log output
   if (!secretsStoreProviderExists) {
-    console.log(chalk.red('--- Azure Secrets Store Provider was not found in the cluster'));
+    let message = `Azure Secrets Store Provider was not found in the cluster`;
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- Azure Secrets Store Provider is installed'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'Azure Secrets Store Provider is installed'
+    }
+    );
   }
 
   return {
@@ -366,9 +375,18 @@ export function checkForAzureManagedPodIdentity(clusterDetails) {
 
   // Log output
   if (!managedPodIdentityEnabled) {
-    console.log(chalk.red('--- Azure Managed Identity for pods is not enabled'));
+    let message = `Azure Managed Identity for pods is not enabled`;
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- Azure Managed Identity for pods is enabled'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'Azure Managed Identity for pods is enabled'
+    }
+    );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -196,12 +196,23 @@ export function checkForSingleReplicas(deployments) {
 
   // Log output
   if (deploymentsWithOneReplica.length) {
-    console.log(chalk.red(`--- Found ${deploymentsWithOneReplica.length} deployments with a single replica`));
+    let message = `Found ${deploymentsWithOneReplica.length} deployments with a single replica`;
+
     if (global.verbose) {
-      deploymentsWithOneReplica.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
+      deploymentsWithOneReplica.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
     }
+
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- All deployments have more than one replica'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'All deployments have more than one replica'
+    }
+    );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -502,12 +502,23 @@ export function checkForPodsWithDefaultSecurityContext(pods) {
 
   // Log output
   if (podsWithDefaultSecurityContext.length) {
-    console.log(chalk.red(`--- Found ${podsWithDefaultSecurityContext.length} pods using the default security context`));
+    let message = `Found ${podsWithDefaultSecurityContext.length} pods using the default security context`;
+
     if (global.verbose) {
-      podsWithDefaultSecurityContext.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
+      podsWithDefaultSecurityContext.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
     }
+
+    details.push({
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
-    console.log(chalk.green('--- All pods have their security context specified'));
+    details.push({
+      status: ResultStatus.Pass,
+      message: 'All pods have their security context specified'
+    }
+    );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -457,11 +457,6 @@ export function checkForPodsWithoutRequestsOrLimits(pods) {
 
   // Log output
   if (podsWithNoRequestsOrLimits.length) {
-    console.log(chalk.red(`--- Found ${podsWithNoRequestsOrLimits.length} pods without either resource requests or limits`));
-    if (global.verbose) {
-      podsWithNoRequestsOrLimits.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
-    }
-
     let message = `Found ${podsWithNoRequestsOrLimits.length} pods without either resource requests or limits`;
 
     if (global.verbose) {

--- a/modules/development.js
+++ b/modules/development.js
@@ -29,20 +29,22 @@ export function checkForLivenessProbes(pods) {
     }
 
     details.push({
-      status:  ResultStatus.Fail,
-      message: message}
-      );
-    
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
+
   } else {
     details.push({
-      status:  ResultStatus.Pass,
-      message: 'All pods have liveness probes'}
-      );
+      status: ResultStatus.Pass,
+      message: 'All pods have liveness probes'
+    }
+    );
   }
 
   return {
     checkId: 'DEV-1',
-    status: !podsWithoutLivenessProbes.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsWithoutLivenessProbes.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Medium,
     details: details
   }
@@ -72,19 +74,21 @@ export function checkForReadinessProbes(pods) {
     }
 
     details.push({
-      status:  ResultStatus.Fail,
-      message: message}
-      );
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
     details.push({
-      status:  ResultStatus.Pass,
-      message: 'All pods have readiness probes'}
-      );
+      status: ResultStatus.Pass,
+      message: 'All pods have readiness probes'
+    }
+    );
   }
 
   return {
     checkId: 'DEV-2',
-    status: !podsWithoutReadinessProbes.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsWithoutReadinessProbes.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Medium,
     details: details
   }
@@ -113,19 +117,21 @@ export function checkForStartupProbes(pods) {
     }
 
     details.push({
-      status:  ResultStatus.Fail,
-      message: message}
-      );
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
     details.push({
-      status:  ResultStatus.Pass,
-      message: 'All pods have startup probes'}
-      );
+      status: ResultStatus.Pass,
+      message: 'All pods have startup probes'
+    }
+    );
   }
 
   return {
     checkId: 'DEV-2B',
-    status: !podsWithoutStartupProbes.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsWithoutStartupProbes.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Medium,
     details: details
   }
@@ -154,19 +160,21 @@ export function checkForPreStopHooks(pods) {
     }
 
     details.push({
-      status:  ResultStatus.Fail,
-      message: message}
-      );
+      status: ResultStatus.Fail,
+      message: message
+    }
+    );
   } else {
     details.push({
-      status:  ResultStatus.Pass,
-      message: 'All pods have preStop hooks'}
-      );
+      status: ResultStatus.Pass,
+      message: 'All pods have preStop hooks'
+    }
+    );
   }
 
   return {
     checkId: 'DEV-3',
-    status: !podsWithoutPreStopHooks.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsWithoutPreStopHooks.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Medium,
     details: details
   }
@@ -198,7 +206,7 @@ export function checkForSingleReplicas(deployments) {
 
   return {
     checkId: 'DEV-4',
-    status: !deploymentsWithOneReplica.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !deploymentsWithOneReplica.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.High,
     details: details
   }
@@ -236,7 +244,7 @@ export function checkForTags(resources) {
 
   return {
     checkId: 'DEV-5',
-    status: !resourcesWithoutTags.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !resourcesWithoutTags.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.High,
     details: details
   }
@@ -267,7 +275,7 @@ export function checkForHorizontalPodAutoscalers(namespaces, autoScalers) {
 
   return {
     checkId: 'DEV-6',
-    status: !namespacesWithoutAutoscalers.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !namespacesWithoutAutoscalers.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Low,
     details: details
   }
@@ -301,7 +309,7 @@ export function checkForAzureSecretsStoreProvider(pods) {
 
   return {
     checkId: 'DEV-7',
-    status: secretsStoreProviderExists.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: secretsStoreProviderExists.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Medium,
     details: details
   }
@@ -329,7 +337,7 @@ export function checkForAzureManagedPodIdentity(clusterDetails) {
 
   return {
     checkId: 'DEV-8',
-    status: managedPodIdentityEnabled? ResultStatus.Pass: ResultStatus.Fail,
+    status: managedPodIdentityEnabled ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.Medium,
     details: details
   }
@@ -358,7 +366,7 @@ export function checkForPodsInDefaultNamespace(pods) {
 
   return {
     checkId: 'DEV-9',
-    status: !podsInDefaultNamespace.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsInDefaultNamespace.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.High,
     details: details
   }
@@ -390,7 +398,7 @@ export function checkForPodsWithoutRequestsOrLimits(pods) {
 
   return {
     checkId: 'DEV-10',
-    status: !podsWithNoRequestsOrLimits.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsWithNoRequestsOrLimits.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.High,
     details: details
   }
@@ -424,7 +432,7 @@ export function checkForPodsWithDefaultSecurityContext(pods) {
 
   return {
     checkId: 'DEV-11',
-    status: !podsWithDefaultSecurityContext.length? ResultStatus.Pass: ResultStatus.Fail,
+    status: !podsWithDefaultSecurityContext.length ? ResultStatus.Pass : ResultStatus.Fail,
     severity: Severity.High,
     details: details
   }

--- a/modules/development.js
+++ b/modules/development.js
@@ -147,12 +147,21 @@ export function checkForPreStopHooks(pods) {
 
   // Log output
   if (podsWithoutPreStopHooks.length) {
-    console.log(chalk.red(`--- Found ${podsWithoutPreStopHooks.length} pods without preStop hooks`));
+    let message = `Found ${podsWithoutPreStopHooks.length} pods without preStop hooks`;
+
     if (global.verbose) {
-      podsWithoutPreStopHooks.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
+      podsWithoutPreStopHooks.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
     }
+
+    details.push({
+      status:  ResultStatus.Fail,
+      message: message}
+      );
   } else {
-    console.log(chalk.green('--- All pods have preStop hooks'));
+    details.push({
+      status:  ResultStatus.Pass,
+      message: 'All pods have preStop hooks'}
+      );
   }
 
   return {

--- a/modules/development.js
+++ b/modules/development.js
@@ -106,16 +106,25 @@ export function checkForStartupProbes(pods) {
 
   // Log output
   if (podsWithoutStartupProbes.length) {
-    console.log(chalk.red(`--- Found ${podsWithoutStartupProbes.length} pods without startup probes`));
+    let message = `Found ${podsWithoutStartupProbes.length} pods without startup probes`;
+
     if (global.verbose) {
-      podsWithoutStartupProbes.forEach(x => console.log(chalk.red(`------ ${x.metadata.namespace} - ${x.metadata.name}`)));
+      podsWithoutStartupProbes.forEach(x => message += `${EOL}${space}${x.metadata.namespace}/${x.metadata.name}`);
     }
+
+    details.push({
+      status:  ResultStatus.Fail,
+      message: message}
+      );
   } else {
-    console.log(chalk.green('--- All pods have startup probes'));
+    details.push({
+      status:  ResultStatus.Pass,
+      message: 'All pods have startup probes'}
+      );
   }
 
   return {
-    checkId: 'DEV-2',
+    checkId: 'DEV-2B',
     status: !podsWithoutStartupProbes.length? ResultStatus.Pass: ResultStatus.Fail,
     severity: Severity.Medium,
     details: details


### PR DESCRIPTION
Resolved a bug where start-up probes check was not coming through in the results table.

But mainly, streamlining the output. For example, when verbose.

```
1. DEV-1 | FAIL - Implement a proper liveness probe
    +------ Found 15 pods without liveness probes
            ingress-nginx/ingress-nginx-controller-65bc98d955-5xkkm
            ingress-nginx/ingress-nginx-controller-65bc98d955-69gtw
            ingress-nginx/ingress-nginx-controller-65bc98d955-8gk7s
            ingress-nginx/lego-renew-1626220800-w28lm
            ingress-nginx/lego-renew-1626307200-2wv2w
            ingress-nginx/lego-renew-1626393600-k9dmm
            kube-system/azure-cni-networkmonitor-64nnc
            kube-system/azure-cni-networkmonitor-6pq42
            kube-system/azure-cni-networkmonitor-hvdqx
            kube-system/azure-ip-masq-agent-7nc95
            kube-system/azure-ip-masq-agent-cx2qw
            kube-system/azure-ip-masq-agent-hgdxj
            kube-system/kube-proxy-g7r2s
            kube-system/kube-proxy-tt89t
            kube-system/kube-proxy-x8bq7

```