### PR TITLE
Fixing issue when azure policy there are no add on profiles configured

### DIFF
--- a/modules/clusterSetup.js
+++ b/modules/clusterSetup.js
@@ -191,7 +191,7 @@ export function checkForAzurePolicy(clusterDetails) {
   let details = [];
 
   // Check if Azure policy is enabled
-  var azurePolicy = clusterDetails.addonProfiles.azurepolicy;
+  var azurePolicy = clusterDetails.addonProfiles?.azurepolicy;
   var azurePolicyConfigured = azurePolicy && azurePolicy.enabled;
 
   // Log output


### PR DESCRIPTION
This fixes #78 

When there were no add-on profiles, Azure Policy check would fail.