### PR TITLE
Replacing Snyk with Trivy

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -54,6 +54,7 @@ jobs:
           output: 'trivy-results.sarif'
           vuln-type: 'os,library'
           security: 'CRITICAL,HIGH'
+          ignore-unfixed: true
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@v2
         if: always()

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -43,10 +43,18 @@ jobs:
       - uses: actions/setup-go@v1
         with:
           go-version: '1.13'
-      - name: Snyk monitor
-        run: snyk test
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      - name: Build an image from Dockerfile
+        run: |
+          docker build -t docker.io/boxboat/aks-health-check:${{ github.sha }} .
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: 'docker.io/boxboat/aks-health-check:${{ github.sha }}'
+					format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          severity: 'CRITICAL,HIGH'
 
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,8 +50,8 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'docker.io/boxboat/aks-health-check:${{ github.sha }}'
-					format: 'table'
-          exit-code: '1'
+	  format: 'table'
+	  exit-code: '1'
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,11 +50,15 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'docker.io/boxboat/aks-health-check:${{ github.sha }}'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
+          format: 'sarif'
+          output: 'trivy-results.sarif'
           vuln-type: 'os,library'
           security: 'CRITICAL,HIGH'
+      - name: Upload Trivy scan results to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -50,11 +50,11 @@ jobs:
         uses: aquasecurity/trivy-action@master
         with:
           image-ref: 'docker.io/boxboat/aks-health-check:${{ github.sha }}'
-	  format: 'table'
-	  exit-code: '1'
-	  ignore-unfixed: true
-	  vuln-type: 'os,library'
-	  security: 'CRITICAL,HIGH'
+          format: 'table'
+          exit-code: '1'
+          ignore-unfixed: true
+          vuln-type: 'os,library'
+          security: 'CRITICAL,HIGH'
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -52,10 +52,9 @@ jobs:
           image-ref: 'docker.io/boxboat/aks-health-check:${{ github.sha }}'
 	  format: 'table'
 	  exit-code: '1'
-          ignore-unfixed: true
-          vuln-type: 'os,library'
-          severity: 'CRITICAL,HIGH'
-
+	  ignore-unfixed: true
+	  vuln-type: 'os,library'
+	  security: 'CRITICAL,HIGH'
   # Push image to GitHub Packages.
   # See also https://docs.docker.com/docker-hub/builds/
   push:


### PR DESCRIPTION
Replacing Snyk with Trivy scans because our Snyk PAT expired and cannot create a new one. 
Trivy scans are uploaded to GitHub Advanced Security